### PR TITLE
Fix createStyles return value

### DIFF
--- a/packages/common/src/lib/create-styles.test.ts
+++ b/packages/common/src/lib/create-styles.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createStyles } from './create-styles.js';
+
+describe('createStyles', () => {
+  const originalWindow = (globalThis as any).window;
+  const originalDocument = (globalThis as any).Document;
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      delete (globalThis as any).window;
+    } else {
+      (globalThis as any).window = originalWindow;
+    }
+
+    if (originalDocument === undefined) {
+      delete (globalThis as any).Document;
+    } else {
+      (globalThis as any).Document = originalDocument;
+    }
+  });
+
+  it('returns a CSSStyleSheet when constructable stylesheets are supported', () => {
+    class FakeSheet {
+      replaceSync(_css: string) {}
+    }
+    (FakeSheet as any).prototype.replaceSync = function () {};
+    const FakeDoc = function () {} as any;
+    FakeDoc.prototype = { adoptedStyleSheets: [] };
+
+    (globalThis as any).window = { CSSStyleSheet: FakeSheet };
+    (globalThis as any).Document = FakeDoc;
+
+    const result = createStyles('body{}');
+    expect(result).toBeInstanceOf(FakeSheet);
+  });
+});
+

--- a/packages/common/src/lib/create-styles.ts
+++ b/packages/common/src/lib/create-styles.ts
@@ -10,21 +10,15 @@ const hasConstructableStylesheetsSupport = () =>
 
 export const createStyles = (cssText: string) => {
   if (!hasConstructableStylesheetsSupport()) {
-    return css`
-      ${unsafeCSS(cssText)}
-    `;
+    return css`${unsafeCSS(cssText)}`;
   }
 
   try {
     const sheet = new CSSStyleSheet();
     sheet.replaceSync(cssText);
-    return css`
-      ${unsafeCSS(cssText)}
-    `;
+    return sheet;
   } catch (error) {
     warn("Failed to create CSSStyleSheet:", error);
-    return css`
-      ${unsafeCSS(cssText)}
-    `;
+    return css`${unsafeCSS(cssText)}`;
   }
 };


### PR DESCRIPTION
## Summary
- fix `createStyles` to return `CSSStyleSheet` when supported
- add regression test for constructable stylesheets

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6868004200848329b00438bff922427d